### PR TITLE
Epic directive

### DIFF
--- a/app/assets/javascripts/angular/app.js.erb
+++ b/app/assets/javascripts/angular/app.js.erb
@@ -1,4 +1,4 @@
-var DevBox = angular.module('DevBox',['ngRoute', 'ngResource', 'ngMaterial', 'ngSanitize', 'angularMoment', 'markdowned']);
+var DevBox = angular.module('DevBox',['ngRoute', 'ngResource', 'ngMaterial', 'ngSanitize', 'angularMoment', 'markdowned', 'ui.epiceditor']);
 
 DevBox.run(['$rootScope', 'UserService', function($rootScope, UserService) {
   console.log("I am running!")

--- a/app/assets/javascripts/angular/controllers/ToolsShowCtrl.js
+++ b/app/assets/javascripts/angular/controllers/ToolsShowCtrl.js
@@ -82,13 +82,12 @@ DevBox.controller( 'ToolsShowCtrl', [ '$scope' , '$resource', '$http', '$locatio
     if ( !$scope.userRating || $scope.userRating < 1 ) {
       Materialize.toast('please add a rating', 4000)
     } else {
-      var content = editor.exportFile();
       var review = new Review();
-      review.post = content;
+      review.post = $scope.userPost;
       review.rating = $scope.userRating;
       review.tool_id = $routeParams.id;
       review.$save(function(data) {
-        console.log(data);
+
         // Add new comment to list
         $scope.tool.reviews_users.unshift(data.result);
 
@@ -101,9 +100,6 @@ DevBox.controller( 'ToolsShowCtrl', [ '$scope' , '$resource', '$http', '$locatio
         $scope.userPost = data.result.review.post
         $scope.userReviewCreatedAt = data.result.review.created_at
         $scope.tool.tool.avg_rating = data.result.avg_rating
-        // Clear the editor
-        editor.edit();
-        editor.getElement('editor').body.innerHTML = '';
       })
     }
   }
@@ -113,20 +109,18 @@ DevBox.controller( 'ToolsShowCtrl', [ '$scope' , '$resource', '$http', '$locatio
     if ( !$scope.userRating || $scope.userRating < 1 ) {
       Materialize.toast('please add a rating', 4000)
     } else {
-      var content = editor.exportFile();
       var review = {}
-      review.post = content;
+      review.post = $scope.userPost;
       review.rating = $scope.userRating;
       review.id = $scope.userReviewId;
 
       Review.update({id: $scope.userReviewId}, review, function(data) {
-          console.log(data);
           $scope.editingReview = false;
           $scope.userRating = data.result.rating
           $scope.userPost = data.result.post
           $scope.userReviewUpdatedAt = data.result.updated_at
           $scope.tool.tool.avg_rating = data.avg_rating
-          console.log()
+
           Materialize.toast('review updated', 4000)
         })
       }
@@ -134,7 +128,6 @@ DevBox.controller( 'ToolsShowCtrl', [ '$scope' , '$resource', '$http', '$locatio
 
   $scope.editReview = function() {
     $scope.editingReview = true;
-    editor.importFile('edit', $scope.userPost)
   }
 
   $scope.displayRating = function( idx ) {

--- a/app/assets/javascripts/angular/directives/angular-epiceditor.js
+++ b/app/assets/javascripts/angular/directives/angular-epiceditor.js
@@ -1,0 +1,90 @@
+// Angular-EpicEditor slighly modified from https://github.com/e154/angular-epiceditor
+
+(function(){
+  'use strict';
+
+  angular
+    .module('ui.epiceditor', [])
+    .directive('uiEpicEditor', function(){
+      return {
+        replace: true,
+        scope: {
+          'ngModel': "="
+        },
+        template:'<div class="epic-editor"></div>',
+        link: function(scope, element, attrs, ngModel) {
+
+          var opts = {
+              container: element.get(0),
+              textarea: null,
+              basePath: '/admin/static/private/bower_components/EpicEditor/epiceditor',
+              clientSideStorage: false,
+              localStorageName: 'epiceditor',
+              useNativeFullscreen: true,
+              parser: marked,
+              file: {
+                  name: 'epiceditor',
+                  defaultContent: '',
+                  autoSave: 100
+              },
+              theme: {
+                base: 'https://rawgit.com/ncronquist/4c9211a66a627286f6c8/raw/562c29dfc024c2cdf21786eeceda55403599bd37/epiceditor.css',
+                preview: 'https://rawgit.com/ncronquist/82821f114e29876a7a7c/raw/fffc2a8b6fbcfa0abdef124c784ef1befe1efaba/epic-dark.css',
+                editor: 'https://rawgit.com/ncronquist/82821f114e29876a7a7c/raw/fffc2a8b6fbcfa0abdef124c784ef1befe1efaba/epic-dark.css'
+              },
+              button: {
+                  preview: true,
+                  fullscreen: true,
+                  bar: "auto"
+              },
+              focusOnLoad: true,
+              shortcut: {
+                  modifier: 18,
+                  fullscreen: 70,
+                  preview: 80
+              },
+              string: {
+                  togglePreview: 'Toggle Preview Mode',
+                  toggleEdit: 'Toggle Edit Mode',
+                  toggleFullscreen: 'Enter Fullscreen'
+              },
+              autogrow: {
+                  minHeight: 250,
+                  maxHeight: false,
+                  scroll: true
+              }
+          };
+
+          var editor = new EpicEditor(opts);
+
+          editor.load(function () {
+
+            var iFrameEditor = editor.getElement('editor');
+
+            // we get body dom element, because this is contenteditable=true
+            // http://stackoverflow.com/questions/6256342/trigger-an-event-when-contenteditable-is-changed
+            var contents = $('body',iFrameEditor).html();
+            $('body',iFrameEditor).blur(function() {
+              if (contents!=$(this).html()){
+                  contents = $(this).html(); // set to new content
+                  editor.save(); // important!
+                  scope.ngModel = editor.exportFile();
+                  scope.$apply();
+              }
+            });
+          });
+
+          // Editor unloaded
+          scope.$on('$destroy', function (event, next, current) {
+            editor.unload(function () {
+                //...
+            });
+          });
+
+          scope.$watch('ngModel', function (newValue, oldValue) {
+            editor.importFile('content', newValue);
+          });
+        }
+      }
+    });
+}());

--- a/app/assets/javascripts/scripts.js
+++ b/app/assets/javascripts/scripts.js
@@ -1,7 +1,5 @@
-$( document ).ready(function(){
-
-  console.log("Did the document ready script run?");
-
+$(function() {
+  
   // Initialize sidebar nav
   $(".button-collapse").sideNav();
   $('.tooltipped').tooltip({delay: 50});

--- a/app/assets/templates/tools/show.html
+++ b/app/assets/templates/tools/show.html
@@ -134,7 +134,6 @@
     <div class="row">
 
       <form ng-show="userRated == false || editingReview">
-        <!-- <legend>Add a Review</legend> -->
         <span>Add a Review</span>
         <span ng-repeat="i in getNumber(number) track by $index">
           <i ng-if="userRating >= $index + 1" ng-mouseenter="displayRating($index)" ng-mouseleave="resetRatingDisplay()" ng-click="setRating($index)" id={{$index}} class="mouse mdi-hardware-mouse liked"></i>
@@ -143,8 +142,7 @@
         </span>
         <div class="input-field">
           <div class="form-group">
-            <textarea id="post" ng-model="post" style="display:none"></textarea>
-            <div id="epiceditor"></div>
+            <textarea id="epiceditor" ui:epic-editor ng-model="userPost"></textarea>
           </div>
         </div>
         <button ng-if="!editingReview" ng-click="saveReview()" id="save-comment-btn" class="btn waves-effect waves-light deep-purple lighten-1" type="button">Add Review</button>
@@ -189,45 +187,3 @@
 
   </div>
 </div>
-
-<script>
-
-  var opts = {
-    container: 'epiceditor',
-    textarea: post,
-    basePath: '../../',
-    clientSideStorage: false,
-    localStorageName: 'epiceditor',
-    useNativeFullscreen: true,
-    parser: marked,
-    file: {
-      name: 'epiceditor',
-      defaultContent: '',
-      autoSave: 100
-    },
-    theme: {
-      base: 'https://rawgit.com/ncronquist/4c9211a66a627286f6c8/raw/562c29dfc024c2cdf21786eeceda55403599bd37/epiceditor.css',
-      preview: 'https://rawgit.com/ncronquist/82821f114e29876a7a7c/raw/fffc2a8b6fbcfa0abdef124c784ef1befe1efaba/epic-dark.css',
-      editor: 'https://rawgit.com/ncronquist/82821f114e29876a7a7c/raw/fffc2a8b6fbcfa0abdef124c784ef1befe1efaba/epic-dark.css'
-    },
-    button: {
-      preview: false,
-      fullscreen: false,
-      bar: true
-    },
-    focusOnLoad: false,
-    shortcut: {
-      modifier: 18,
-      fullscreen: 70,
-      preview: 80
-    },
-    string: {
-      togglePreview: 'Toggle Preview Mode',
-      toggleEdit: 'Toggle Edit Mode',
-      toggleFullscreen: 'Enter Fullscreen'
-    },
-    autogrow: false
-  }
-  var editor = new EpicEditor(opts).load();
-
-</script>


### PR DESCRIPTION
This pull request updates Epic Editor to use a directive rather than an inline script in the html. 

I was hoping I would be able to drop this right into the description field on the new and edit tools page, but the way our current category drop downs work breaks Epic Editor. I figured for now I'll push up this change and then work on the description editing separately.

**Note** -  I renamed `show.html.erb` to just `show.html`. In this merge it looks correct, but when you pull it in locally, make sure you don't accidentally end up with two files.
