### PR TITLE
Tool Form, Markdown Descriptions

### DIFF
--- a/app/assets/javascripts/angular/controllers/ToolsEditCrtl.js
+++ b/app/assets/javascripts/angular/controllers/ToolsEditCrtl.js
@@ -37,7 +37,6 @@ DevBox.controller( 'ToolsEditCtrl', [ '$scope' , '$resource', '$location', '$htt
       $scope.category03Pre = data.categories[2] || null;
       $scope.categories = data.allCategories;
 
-      console.log(data.tags);
     })
   }
 
@@ -57,22 +56,18 @@ DevBox.controller( 'ToolsEditCtrl', [ '$scope' , '$resource', '$location', '$htt
       tool.doc_url = $scope.doc_url;
       tool.categories = [$scope.category01Pre, $scope.category02Pre, $scope.category03Pre];
       tool.tags = $scope.selectedTags;
-      console.log(tool)
-      Tool.update({id: $routeParams.id},tool,function(data){
-        console.log(data)
-        Materialize.toast('edit successful', 4000)
-        $location.url("/tools/" + $routeParams.id)
-      });
-      //   function(data) {
-      //   console.log(data);
-      //   $location.url("/tools/" + data.result.id)
-      // })
+      Tool.update({id: $routeParams.id},tool,
+        function(data){
+          Materialize.toast('edit successful', 4000)
+          $location.url("/tools/" + $routeParams.id)
+        },
+        function(err) {
+          Materialize.toast('Uh-oh :/ Try refreshing', 4000)
+        });
     }
   }
 
   $scope.newTag = function(chip) {
-    // console.log("New Tag Function");
-    // console.log("Chip.tag:", chip.tag);
     if ( chip.tag ) {
       return chip;
     }
@@ -82,17 +77,13 @@ DevBox.controller( 'ToolsEditCtrl', [ '$scope' , '$resource', '$location', '$htt
   }
 
   function querySearch (query) {
-    // console.log("query search")
     var results = query ? $scope.tags.filter(createFilterFor(query)) : [];
-    // console.log("Results:", results);
     return results;
   }
 
   function createFilterFor(query) {
     var lowercaseQuery = angular.lowercase(query);
     return function filterFn(tag) {
-      // console.log("tag.tag", tag.tag);
-      // console.log("lowercaseQuery", lowercaseQuery);
       return (tag.tag.indexOf(lowercaseQuery) === 0);
     };
   }

--- a/app/assets/javascripts/angular/controllers/ToolsEditCrtl.js
+++ b/app/assets/javascripts/angular/controllers/ToolsEditCrtl.js
@@ -11,6 +11,12 @@ DevBox.controller( 'ToolsEditCtrl', [ '$scope' , '$resource', '$location', '$htt
   $scope.numberChips2 = [];
   $scope.numberBuffer = '';
   $scope.tool = {};
+  $scope.$watch.isFormattingHelpOpen = false;
+
+  $scope.formattingHelp = function(action){
+    console.log('boop')
+    $scope.isFormattingHelpOpen = action;
+  }
 
   Tool = $resource('/api/tools/:id', null, {
     'update': { method:'PUT' }
@@ -33,8 +39,6 @@ DevBox.controller( 'ToolsEditCtrl', [ '$scope' , '$resource', '$location', '$htt
       $scope.selectedTags = data.tags;
       $scope.tags = data.allTags;
       $scope.category01Pre = data.categories[0] || null;
-      $scope.category02Pre = data.categories[1] || null;
-      $scope.category03Pre = data.categories[2] || null;
       $scope.categories = data.allCategories;
 
     })
@@ -54,7 +58,7 @@ DevBox.controller( 'ToolsEditCtrl', [ '$scope' , '$resource', '$location', '$htt
       tool.web_url = $scope.web_url;
       tool.repo_url = $scope.repo_url;
       tool.doc_url = $scope.doc_url;
-      tool.categories = [$scope.category01Pre, $scope.category02Pre, $scope.category03Pre];
+      tool.categories = [$scope.category01Pre];
       tool.tags = $scope.selectedTags;
       Tool.update({id: $routeParams.id},tool,
         function(data){

--- a/app/assets/javascripts/angular/controllers/ToolsNewCtrl.js
+++ b/app/assets/javascripts/angular/controllers/ToolsNewCtrl.js
@@ -8,6 +8,12 @@ DevBox.controller( 'ToolsNewCtrl', [ '$scope' , '$resource', '$location', functi
   $scope.numberChips = [];
   $scope.numberChips2 = [];
   $scope.numberBuffer = '';
+  $scope.$watch.isFormattingHelpOpen = false;
+
+  $scope.formattingHelp = function(action){
+    console.log('boop')
+    $scope.isFormattingHelpOpen = action;
+  }
 
   Tool = $resource('/api/tools/', null, {
     'update': { method:'PUT' }
@@ -36,7 +42,7 @@ DevBox.controller( 'ToolsNewCtrl', [ '$scope' , '$resource', '$location', functi
     tool.repo_url = $scope.repo_url;
     tool.doc_url = $scope.doc_url;
     tool.avg_rating = null;
-    tool.categories = [$scope.category01, $scope.category02, $scope.category03];
+    tool.categories = [$scope.category01];
     tool.tags = $scope.selectedTags;
     tool.$save(function(data) {
       console.log(data);

--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -481,6 +481,10 @@ form.big-text {
   font-size: 1.6rem;
 }
 
+label {
+  font-size: 1.6rem;
+}
+
 [type="radio"]:not(:checked)+label, [type="radio"]:checked+label {
   font-size: 1.6rem;
 }

--- a/app/assets/templates/tools/edit.html
+++ b/app/assets/templates/tools/edit.html
@@ -6,36 +6,50 @@
       <div class="input-field col s12">
         <input ng-model="title" id="title" class="active" type="text" placeholder="Title">
 
-        <!-- <md-tooltip md-visible="true">tool titles must be unique</md-tooltip> -->
+        <md-tooltip md-visible="true">tool titles must be unique</md-tooltip>
       </div>
     </div>
 
     <div class="row">
       <div class="input-field col s12">
         <textarea ng-model="description" id="description" class="materialize-textarea" placeholder="Description"></textarea>
-
       </div>
-    </div>
-
-    <div class="row input-label">
-      Choose up to three categories
+      <div class="markdownHelper">
+        <a href="#" ng-hide="isFormattingHelpOpen" ng-click="formattingHelp(true)">Show Formatting Help</a>
+        <a href="#" ng-show="isFormattingHelpOpen" ng-click="formattingHelp(false)">Hide Formatting Help</a>
+        <div ng-show="isFormattingHelpOpen" class="card-panel blue-grey darken-2">
+          <p>Reviews on DevBox.tools are formatted with markdown.</p>
+          <table>
+            <tr>
+              <td width="50%">
+                <ul>
+                  <li>italics: *this* or _this_ equals <em>this</em></li>
+                  <li>bold: **this** or __this__ equals <strong>this</strong></li>
+                  <li>strikethrough: ~~this~~ equals <del>this</del></li>
+                  <li>inline code: `this` equals <code>this</code></li>
+                  <li>block code: ```a block of multi line code```</li>
+                </ul>
+              </td>
+              <td width="50%">
+                <ol>
+                  <li>Ordered lists begin with a number.</li>
+                </ol>
+                <ul>
+                  <li>Unordered lists begin with either * , - , or + (notice the space that follows).</li>
+                </ul>
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
     </div>
 
     <div class="row">
       <div class="col m4">
-        <md-select ng-model="category01Pre" placeholder="Category">
+        <md-select ng-model="category01Pre" id="category01Pre" placeholder="Category">
           <md-option ng-repeat="category in categories" ng-selected="{{category.category == category01Pre.category}}" value="{{category.id}}">{{category.category}}</md-option>
         </md-select>
-      </div>
-      <div class="col m4">
-        <md-select ng-model="category02Pre" placeholder="Category">
-          <md-option ng-repeat="category in categories" ng-selected="{{category.category == category02Pre.category}}" value="{{category.id}}">{{category.category}}</md-option>
-        </md-select>
-      </div>
-      <div class="col m4">
-        <md-select ng-model="category03Pre" placeholder="Category">
-          <md-option ng-repeat="category in categories" ng-selected="{{category.category == category03Pre.category}}" value="{{category.id}}">{{category.category}}</md-option>
-        </md-select>
+        <label for="category01Pre">Category</label>
       </div>
     </div>
 
@@ -112,10 +126,8 @@
     <div class="row">
       <div class="col s12">
         <button ng-if="$root.isAuthenticated === true" ng-click="updateTool()" id="save-tool-btn" class="btn waves-effect waves-light deep-purple lighten-1" type="button">Submit
-          <!-- <i class="mdi-content-send right"></i> -->
         </button>
         <button ng-if="$root.isAuthenticated === false" id="save-tool-btn" class="btn waves-effect waves-light deep-purple lighten-1" type="button">Submit<md-tooltip>login to edit</md-tooltip>
-          <!-- <i class="mdi-content-send right"></i> -->
         </button>
       </div>
     </div>

--- a/app/assets/templates/tools/new.html
+++ b/app/assets/templates/tools/new.html
@@ -21,21 +21,50 @@
     <div class="row">
       <div class="input-field col s12">
         <textarea ng-model="description" id="description" class="materialize-textarea"></textarea>
-        <label for="description">Description</label>
+        <label for="description">Description (Markdown)</label>
+      </div>
+      <div class="markdownHelper">
+        <a href="#" ng-hide="isFormattingHelpOpen" ng-click="formattingHelp(true)">Show Formatting Help</a>
+        <a href="#" ng-show="isFormattingHelpOpen" ng-click="formattingHelp(false)">Hide Formatting Help</a>
+        <div ng-show="isFormattingHelpOpen" class="card-panel blue-grey darken-2">
+          <p>Reviews on DevBox.tools are formatted with markdown.</p>
+          <table>
+            <tr>
+              <td width="50%">
+                <ul>
+                  <li>italics: *this* or _this_ equals <em>this</em></li>
+                  <li>bold: **this** or __this__ equals <strong>this</strong></li>
+                  <li>strikethrough: ~~this~~ equals <del>this</del></li>
+                  <li>inline code: `this` equals <code>this</code></li>
+                  <li>block code: ```a block of multi line code```</li>
+                </ul>
+              </td>
+              <td width="50%">
+                <ol>
+                  <li>Ordered lists begin with a number.</li>
+                </ol>
+                <ul>
+                  <li>Unordered lists begin with either * , - , or + (notice the space that follows).</li>
+                </ul>
+              </td>
+            </tr>
+          </table>
+        </div>
       </div>
     </div>
 
-    <div class="row input-label">
+<!--     <div class="row input-label">
       Choose up to three categories
-    </div>
+    </div> -->
 
     <div class="row">
       <div class="col m4">
         <md-select ng-model="category01" placeholder="Category">
           <md-option ng-repeat="category in categories" value="{{category.id}}">{{category.category}}</md-option>
         </md-select>
+        <label for="category01Pre">Category</label>
       </div>
-      <div class="col m4">
+<!--       <div class="col m4">
         <md-select ng-model="category02" placeholder="Category">
           <md-option ng-repeat="category in categories" value="{{category.id}}">{{category.category}}</md-option>
         </md-select>
@@ -44,7 +73,7 @@
         <md-select ng-model="category03" placeholder="Category">
           <md-option ng-repeat="category in categories" value="{{category.id}}">{{category.category}}</md-option>
         </md-select>
-      </div>
+      </div> -->
     </div>
 
     <div class="row">

--- a/app/assets/templates/tools/show.html
+++ b/app/assets/templates/tools/show.html
@@ -48,9 +48,9 @@
     </div>
     <div class="row">
       <div class="col s12 m10 offset-m1">
-        <div class="card-panel blue-grey darken-2">
+        <div class="card-panel blue-grey darken-2 review">
           <a ng-href="{{tool.tool.web_url}}"><span class="small mdi-social-public"></span><md-tooltip ng-if="tool.tool.web_url">website</md-tooltip><md-tooltip ng-if="!!tool.tool.web_url == false">no website</md-tooltip></a> <a ng-href="{{tool.tool.doc_url}}"><span class="mdi-action-description"></span><md-tooltip ng-if="tool.tool.doc_url">docs</md-tooltip><md-tooltip ng-if="!!tool.tool.doc_url == false">no docs</md-tooltip></a> <a ng-href="{{tool.tool.repo_url}}"><span class="mdi-communication-call-split"></span><md-tooltip ng-if="tool.tool.repo_url">repository</md-tooltip><md-tooltip ng-if="!!tool.tool.repo_url == false">no repo</md-tooltip></a> <a ng-if="$root.isAuthenticated" ng-href="/tools/{{tool.tool.id}}/edit"><span class="mdi-editor-mode-edit"></span><md-tooltip ng-if="$root.isAuthenticated === true">edit this tool</md-tooltip></a><span ng-if="isAuthenticated === false"><span class="mdi-editor-mode-edit"></span><md-tooltip ng-if="$root.isAuthenticated === false">log in to edit</md-tooltip></span>
-          <p>{{tool.tool.description}}</p>
+          <div markdown="tool.tool.description"></div>
         </div>
       </div>
     </div>

--- a/app/models/categories_tools.rb
+++ b/app/models/categories_tools.rb
@@ -4,7 +4,8 @@ class CategoriesTools < ActiveRecord::Base
   belongs_to :tool
 
   validates :category_id, presence: true, numericality: { only_integer: true }
-  validates :tool_id, presence: true, numericality: { only_integer: true }
+  validates :tool_id, uniqueness: true, presence: true, numericality: { only_integer: true }
+
   # validates :tool_categories_count, on: :create
 
   # def tool_categories_count

--- a/db/migrate/20150704053759_add_tool_id_index_to_categories_tools.rb
+++ b/db/migrate/20150704053759_add_tool_id_index_to_categories_tools.rb
@@ -1,0 +1,11 @@
+class AddToolIdIndexToCategoriesTools < ActiveRecord::Migration
+  def up
+    remove_index :categories_tools, :tool_id
+    remove_index :categories_tools, :category_id
+    add_index :categories_tools, :tool_id, unique: true
+  end
+
+  def down
+    remove_index :categories_tools, :tool_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150603232952) do
+ActiveRecord::Schema.define(version: 20150704053759) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,8 +29,7 @@ ActiveRecord::Schema.define(version: 20150603232952) do
     t.datetime "updated_at",  null: false
   end
 
-  add_index "categories_tools", ["category_id"], name: "index_categories_tools_on_category_id", using: :btree
-  add_index "categories_tools", ["tool_id"], name: "index_categories_tools_on_tool_id", using: :btree
+  add_index "categories_tools", ["tool_id"], name: "index_categories_tools_on_tool_id", unique: true, using: :btree
 
   create_table "reviews", force: :cascade do |t|
     t.text     "post"


### PR DESCRIPTION
This request:
- Adds markdown formatting to tool descriptions
- Adds Markdown help to Description input fields
- Only allows 1 category per tool

This request will require the following query to be run on your dev_box database until it removes 0 rows (Yes, this is a crappy way to do this, but it's only once and we're still in development):

```
-- This query will delete extra categories from tools where there is more than one category
-- Each time the query is run, it will delete the newest extra category
-- Repeat until there are no rows returned
DELETE FROM categories_tools
WHERE id in 
    (SELECT max(id)
    FROM categories_tools
    WHERE tool_id in 
        (SELECT tool_id
        FROM categories_tools
        Group by tool_id
        Having count(*) > 1)
    GROUP BY tool_id)
```

After running the query, you will need to run `rake db:migrate` to update the database indexes.
